### PR TITLE
Correct the Xing offset for Mpeg1 Non-Mono

### DIFF
--- a/src/Id3.Net/Mp3/AudioStream.cs
+++ b/src/Id3.Net/Mp3/AudioStream.cs
@@ -57,7 +57,7 @@ namespace Id3
 
             int modeIndex = ModeIndex;
             if (VersionIndex == 3)
-                position += modeIndex == 3 ? 17 : 19;
+                position += modeIndex == 3 ? 17 : 32;
             else
                 position += modeIndex == 3 ? 9 : 17;
 


### PR DESCRIPTION
Fixes #38 

It looks like an incorrect offset into the header is being calculated for the Xing identifier causing the code to think that this is a CBR file rather than the VBR it is and thus getting the files duration calculating wrong.