### PR TITLE
implement WriteTag wipeout and shrinking options

### DIFF
--- a/src/Id3.Net/Id3/Id3Handler.cs
+++ b/src/Id3.Net/Id3/Id3Handler.cs
@@ -89,7 +89,7 @@ namespace Id3
         internal abstract byte[] GetTagBytes(Stream stream);
         internal abstract bool HasTag(Stream stream);
         internal abstract Id3Tag ReadTag(Stream stream, out object additionalData);
-        internal abstract bool WriteTag(Stream stream, Id3Tag tag);
+        internal abstract bool WriteTag(Stream stream, Id3Tag tag, WriteTagOptions options);
         #endregion
 
         #region ID3 tag properties for the handler

--- a/src/Id3.Net/Id3/v1/Id3v1Handler.cs
+++ b/src/Id3.Net/Id3/v1/Id3v1Handler.cs
@@ -98,7 +98,7 @@ namespace Id3.v1
             return tag;
         }
 
-        internal override bool WriteTag(Stream stream, Id3Tag tag)
+        internal override bool WriteTag(Stream stream, Id3Tag tag, WriteTagOptions options)
         {
             Encoding encoding = TextEncodingHelper.GetDefaultEncoding();
 

--- a/src/Id3.Net/Mp3/Mp3.cs
+++ b/src/Id3.Net/Mp3/Mp3.cs
@@ -272,10 +272,26 @@ namespace Id3
         #region Tag writing methods
         public bool UpdateTag(Id3Tag tag)
         {
-            return WriteTag(tag, WriteConflictAction.Replace);
+            return WriteTag(tag, new WriteTagOptions() { ConflictAction = WriteConflictAction.Replace });
         }
 
         public bool WriteTag(Id3Tag tag, WriteConflictAction conflictAction = WriteConflictAction.NoAction)
+        {
+            return WriteTag(tag, new WriteTagOptions() { ConflictAction = conflictAction });
+        }
+
+        public bool WriteTag(Id3Tag tag, Id3Version version, WriteConflictAction conflictAction = WriteConflictAction.NoAction)
+        {
+            return WriteTag(tag, version, new WriteTagOptions() { ConflictAction = conflictAction });
+        }
+
+        public bool WriteTag(Id3Tag tag, Id3Version version, WriteTagOptions options)
+        {
+            tag.Version = version;
+            return WriteTag(tag, options);
+        }
+
+        public bool WriteTag(Id3Tag tag, WriteTagOptions options)
         {
             if (tag == null)
                 throw new ArgumentNullException(nameof(tag));
@@ -290,9 +306,9 @@ namespace Id3
                 Id3Handler handler = familyHandler;
                 if (handler.Version != tag.Version)
                 {
-                    if (conflictAction == WriteConflictAction.NoAction)
+                    if (options.ConflictAction == WriteConflictAction.NoAction)
                         return false;
-                    if (conflictAction == WriteConflictAction.Replace)
+                    if (options.ConflictAction == WriteConflictAction.Replace)
                     {
                         Id3Handler handlerCopy = handler; //TODO: Why did we need a copy of the handler?
                         handlerCopy.DeleteTag(Stream);
@@ -302,17 +318,10 @@ namespace Id3
 
             //Write the tag to the file. The handler will know how to overwrite itself.
             Id3Handler writeHandler = Id3Handler.GetHandler(tag.Version);
-            bool writeSuccessful = writeHandler.WriteTag(Stream, tag);
+            bool writeSuccessful = writeHandler.WriteTag(Stream, tag, options);
             if (writeSuccessful)
                 InvalidateExistingHandlers();
             return writeSuccessful;
-        }
-
-        public bool WriteTag(Id3Tag tag, Id3Version version,
-            WriteConflictAction conflictAction = WriteConflictAction.NoAction)
-        {
-            tag.Version = version;
-            return WriteTag(tag, conflictAction);
         }
         #endregion
 

--- a/src/Id3.Net/Mp3/WriteTagOptions.cs
+++ b/src/Id3.Net/Mp3/WriteTagOptions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Id3
+{
+    public class WriteTagOptions
+    {
+        public WriteConflictAction ConflictAction { get; set; } = WriteConflictAction.NoAction;
+
+        public bool WipeOut { get; set; } = true;
+
+        public bool ShrinkFile { get; set; } = true;
+
+        public int ShrinkFileThreshold { get; set; } = 0;
+    }
+}


### PR DESCRIPTION
Added implementation for shrinking/wipeout the remaining space when tag size decreases.
This can be controlled by options; however, the defaults are set to shrink the file (if applicable).

This is usefull if tags are removed (especially pictures) or when tags are added/removed/added/removed several times; otherwise the file size will always increase and the removed tag data will remain in the file.